### PR TITLE
Add example using corral to fetch `termax` as dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ Build the mouse-handling example with `ponyc -o bin examples/mousing` and run `b
 
 ![Mousing example video](docs/images/termax.mousing.gif)
 
+### Using Corral
+
+The `using_corral` can be used to test using `termax` via corral. Run the following commands to build the example:
+
+```sh
+cd examples/using_corral
+corral fetch
+corral run -- ponyc -o bin
+```
+
+Now you can run `bin/using_corral` to try the app.
+
 ## Contributing
 
 Bug reports and sugestions are welcome. Otherwise, at this time, this project is closed for code changes and pull requests. I appreciate your understanding.

--- a/examples/using_corral/corral.json
+++ b/examples/using_corral/corral.json
@@ -1,0 +1,17 @@
+{
+  "packages": [],
+  "deps": [
+    {
+      "locator": "github.com/nogginly/termax.pony.git",
+      "version": ">=0.1.0"
+    }
+  ],
+  "info": {
+    "description": "Example using corral to fetch 'termax' as a dependency.",
+    "homepage": "",
+    "license": "",
+    "documentation_url": "",
+    "version": "",
+    "name": "termax_example_using_corral"
+  }
+}

--- a/examples/using_corral/lock.json
+++ b/examples/using_corral/lock.json
@@ -1,0 +1,8 @@
+{
+  "locks": [
+    {
+      "locator": "github.com/nogginly/termax.pony.git",
+      "revision": "0.1.1"
+    }
+  ]
+}

--- a/examples/using_corral/main.pony
+++ b/examples/using_corral/main.pony
@@ -1,0 +1,19 @@
+use "termax"
+
+class _Listen is TerminalNotify
+  let _out: OutStream
+
+  new iso create(env': Env) => 
+    _out = env'.out
+    _out.print("Press Ctrl-C to exit.\nType away ...")
+
+  fun ref apply(term: Terminal ref, input: U8 val) =>
+    match input
+    | 3 => term.dispose()
+    | if (input >= 32) and (input < 127) => _out.write([input])
+    else _out.>write("[" + input.string() + "]")
+    end
+
+actor Main
+  new create(env: Env) =>
+    let term = EasyTerminal(env, _Listen(env))


### PR DESCRIPTION
Add `examples/using_corral` and update `README.md` with section on running it.