### PR TITLE
Color example

### DIFF
--- a/corral.json
+++ b/corral.json
@@ -8,7 +8,7 @@
     "homepage": "https://github.com/nogginly/termax.pony",
     "license": "BSD-2-Clause",
     "documentation_url": "https://github.com/nogginly/termax.pony",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "name": "termax"
   }
 }

--- a/examples/colors/main.pony
+++ b/examples/colors/main.pony
@@ -1,0 +1,39 @@
+use "../../termax"
+
+class _Listen is (TerminalNotify & TerminalTextFormatting)
+  let _out: OutStream
+
+  new iso create(env': Env) => 
+    _out = env'.out
+    _out.print(color_with(" ^R ", Term.red()) 
+                   + color_with(" ^G ", Term.green()) 
+                   + color_with(" ^B ", Term.blue())
+                   + "- Reset " + invert(" ^R ")
+                   + "- Quit " + invert(" ^C ")
+                   + "\nType away ...")
+
+  fun ref _reset_all() =>
+    _out.write(Term.reset())
+
+  fun ref closed() =>
+    _reset_all()
+    _out.print("\n\nBye")
+
+  fun ref apply(term: Terminal ref, input: U8 val) =>
+    match input
+    | Key.ctrl_R() => 
+      _out.write(Term.red())
+    | Key.ctrl_G() => 
+      _out.write(Term.green())
+    | Key.ctrl_B() => 
+      _out.write(Term.blue())
+    | Key.ctrl_C() => term.dispose()
+    | Key.ctrl_R() => _reset_all()
+    | Key.back_space() => _out.write(Term.left() + Term.erase(EraseAfter))
+    | if (input >= 32) and (input < 127) => _out.write([input])
+    else _out.>write(invert("[" + input.string() + "]"))
+    end
+
+actor Main
+  new create(env: Env) =>
+    let term = EasyTerminal(env, _Listen(env))

--- a/termax/term_escape_codes.pony
+++ b/termax/term_escape_codes.pony
@@ -347,6 +347,18 @@ trait TerminalEscapeCodes
     """
     "\e[?1003l\e[?1015l\e[?1006l"
 
+  fun reset_color(): String =>
+    """
+    Resets foreground colour (but not the text styles)
+    """
+    "\e[39m"
+
+  fun reset_color_bg(): String =>
+    """
+    Resets foreground colour (but not the text styles)
+    """
+    "\e[49m"
+
   fun color(fg: U8) : String =>
     """
     Select an 8-bit foreground (text) color. 

--- a/termax/term_text_format.pony
+++ b/termax/term_text_format.pony
@@ -52,6 +52,31 @@ trait TerminalTextFormatting
     """
     Term.strikeout() +  value.string() + Term.strikeout(false)
 
+  fun color(value: Stringable val, fg: U8, bg: (None|U8) = None) : String =>
+    """
+    Return the value escaped by 8-bit colour codes for foreground and 
+    (optional) background colours.
+    """
+    match bg
+    | let bgcolor : U8 => 
+        Term.color(bgcolor) + Term.color(fg) + value.string() + 
+        Term.reset_color() + Term.reset_color_bg()
+    else
+        Term.color(fg) + value.string() + Term.reset_color()
+    end
+
+  fun color_with(value: Stringable val, fg: String, bg: (None|String) = None) : String =>
+    """
+    Return the value surrounded by supplied escape codes for foreground and 
+    (optional) background colours.
+    """
+    match bg
+    | let bgcode : String => 
+        bgcode + fg + value.string() + Term.reset_color() + Term.reset_color_bg()
+    else
+        fg + value.string() + Term.reset_color()
+    end
+
 primitive TermFmt is TerminalTextFormatting
   """
   Use this primitive directly to format strings. 


### PR DESCRIPTION
* Add colour reset codes and color text formatting helpers.
* Add `examples/colors` with very basic text colour formatting